### PR TITLE
Remove extra line

### DIFF
--- a/src/Cron_Command.php
+++ b/src/Cron_Command.php
@@ -1,4 +1,3 @@
-
 <?php
 
 use EE\Model\Cron;


### PR DESCRIPTION
Need to remove the extra line at the top, because due to the autoloading of the commands, this is adding extra new-line while running EasyEngine command line.

Signed-off-by: Riddhesh Sanghvi <riddheshsanghvi96@gmail.com>